### PR TITLE
🎉 Refactor domain event handling via IAggregateRoot

### DIFF
--- a/src/Pokok.BuildingBlocks.Domain/Abstractions/AggregateRoot.cs
+++ b/src/Pokok.BuildingBlocks.Domain/Abstractions/AggregateRoot.cs
@@ -2,7 +2,7 @@
 
 namespace Pokok.BuildingBlocks.Domain.Abstractions
 {
-    public abstract class AggregateRoot<TId> : Entity<TId>
+    public abstract class AggregateRoot<TId> : Entity<TId>, IAggregateRoot
     {
         private readonly List<IDomainEvent> _domainEvents = new();
         public IReadOnlyCollection<IDomainEvent> DomainEvents => _domainEvents.AsReadOnly();

--- a/src/Pokok.BuildingBlocks.Domain/Abstractions/IAggregateRoot.cs
+++ b/src/Pokok.BuildingBlocks.Domain/Abstractions/IAggregateRoot.cs
@@ -1,0 +1,10 @@
+using Pokok.BuildingBlocks.Domain.Events;
+
+namespace Pokok.BuildingBlocks.Domain.Abstractions
+{
+    public interface IAggregateRoot
+    {
+        IReadOnlyCollection<IDomainEvent> DomainEvents { get; }
+        void ClearDomainEvents();
+    }
+}

--- a/src/Pokok.BuildingBlocks.Domain/Abstractions/IAggregateRoot.cs
+++ b/src/Pokok.BuildingBlocks.Domain/Abstractions/IAggregateRoot.cs
@@ -1,4 +1,4 @@
-using Pokok.BuildingBlocks.Domain.Events;
+﻿using Pokok.BuildingBlocks.Domain.Events;
 
 namespace Pokok.BuildingBlocks.Domain.Abstractions
 {

--- a/src/Pokok.BuildingBlocks.Persistence/EfCore/UnitOfWork.cs
+++ b/src/Pokok.BuildingBlocks.Persistence/EfCore/UnitOfWork.cs
@@ -31,25 +31,23 @@ namespace Pokok.BuildingBlocks.Persistence
             if (_domainEventDispatcher is null) 
                 return result;
 
-            // Collect domain events from aggregates
             var aggregates = _context.ChangeTracker
                 .Entries()
-                .Where(e => e.Entity is AggregateRoot<object>) // detect aggregates
-                .Select(e => e.Entity as AggregateRoot<object>)
-                .Where(e => e is not null)
+                .Where(e => e.Entity is IAggregateRoot)
+                .Select(e => (IAggregateRoot)e.Entity)
                 .ToList();
 
             var domainEvents = aggregates
-                .SelectMany(a => a!.DomainEvents)
+                .SelectMany(a => a.DomainEvents)
                 .ToList();
 
-            // Clear them from the aggregates
-            aggregates.ForEach(a => a!.ClearDomainEvents());
+            aggregates.ForEach(a => a.ClearDomainEvents());
 
             if (domainEvents.Count > 0)
+            {
                 _logger.LogInformation("Dispatching {Count} domain events from {Context}", domainEvents.Count, typeof(TContext).Name);
-
-            await _domainEventDispatcher.DispatchAsync(domainEvents, cancellationToken);
+                await _domainEventDispatcher.DispatchAsync(domainEvents, cancellationToken);
+            }
 
             return result;
         }


### PR DESCRIPTION
This pull request introduces a new `IAggregateRoot` interface and updates the domain and persistence layers to use this abstraction for better flexibility and consistency in handling aggregates and domain events. The most important changes are:

**Domain Layer Abstractions:**

* Added a new `IAggregateRoot` interface in `Pokok.BuildingBlocks.Domain.Abstractions`, which exposes the `DomainEvents` property and a `ClearDomainEvents` method.
* Updated the `AggregateRoot<TId>` class to implement the new `IAggregateRoot` interface, aligning it with the new abstraction.

**Persistence Layer Improvements:**

* Modified the domain event collection and dispatch logic in `UnitOfWork.cs` to work with the `IAggregateRoot` interface instead of the concrete `AggregateRoot<object>` type, improving flexibility and type safety.